### PR TITLE
fix: socks5 proxy rejected connection - failure

### DIFF
--- a/src/lambda/tailscale-proxy/index.ts
+++ b/src/lambda/tailscale-proxy/index.ts
@@ -7,7 +7,7 @@ import {
 import { SocksProxyAgent } from 'socks-proxy-agent';
 
 async function proxyHttpRequest(
-  target: Pick<http.RequestOptions, 'hostname' | 'port' | 'agent'>,
+  target: Pick<http.RequestOptions, 'hostname' | 'port'>,
   isHttps: boolean | undefined,
   request: {
     path: string;
@@ -16,53 +16,83 @@ async function proxyHttpRequest(
     body: string | undefined;
   },
 ): Promise<APIGatewayProxyResultV2> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    const httpLib = isHttps == undefined ?
-      (target.port == 443 ? https : http) :
-      (isHttps ? https : http);
-    const apiRequest = httpLib.request({
-      ...target,
-      path: request.path,
-      method: request.method,
-      headers: request.headers,
-    }, (res: http.IncomingMessage) => {
-      res.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-      res.on('end', () => {
-        const responseBody = Buffer.concat(chunks);
-        resolve({
-          statusCode: res.statusCode || 500,
-          headers: res.headers as Record<string, string>,
-          body: responseBody.toString('base64'),
-          isBase64Encoded: true,
+
+  async function requestPromise(): Promise<APIGatewayProxyResultV2> {
+    const socksProxyAgent = new SocksProxyAgent('socks://localhost:1055');
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      const httpLib = isHttps == undefined ?
+        (target.port == 443 ? https : http) :
+        (isHttps ? https : http);
+      const apiRequest = httpLib.request({
+        ...target,
+        agent: socksProxyAgent,
+        path: request.path,
+        method: request.method,
+        headers: request.headers,
+      }, (res: http.IncomingMessage) => {
+        res.on('data', (chunk: Buffer) => {
+          chunks.push(chunk);
+        });
+        res.on('end', () => {
+          const responseBody = Buffer.concat(chunks);
+          resolve({
+            statusCode: res.statusCode || 500,
+            headers: res.headers as Record<string, string>,
+            body: responseBody.toString('base64'),
+            isBase64Encoded: true,
+          });
+        });
+        res.on('error', (error: Error): void => {
+          console.error('Error receiving response:', error);
+          reject(error);
         });
       });
-      res.on('error', (error: Error): void => {
-        console.error('Error receiving response:', error);
+
+      apiRequest.on('error', (error: Error): void => {
+        console.error('Error sending request:', error);
         reject(error);
       });
-    });
 
-    apiRequest.on('error', (error: Error): void => {
-      console.error('Error sending request:', error);
-      reject(error);
+      if (request.body != null) {
+        apiRequest.write(request.body);
+      }
+      apiRequest.end();
     });
+  }
 
-    if (request.body != null) {
-      apiRequest.write(request.body);
+
+  const connectionRetryDelays = [10, 50, 100, 500, 1000, 2000, 3000];
+  let attempt = 0;
+  let success = false;
+  let response: APIGatewayProxyResultV2;
+
+  do {
+    try {
+      response = await requestPromise();
+      success = true;
+    } catch (error) {
+      if (error == 'Error: Socks5 proxy rejected connection - Failure' && attempt < connectionRetryDelays.length) {
+        console.error('Error: Socks5 proxy rejected connection - Failure');
+        console.log('Retrying in', connectionRetryDelays[attempt], 'ms');
+        await new Promise((resolve) => setTimeout(resolve, connectionRetryDelays[attempt]));
+        attempt++;
+      } else {
+        throw error;
+      }
     }
-    apiRequest.end();
-  });
+  } while (!success && attempt < connectionRetryDelays.length);
+
+  if (attempt > 0) {
+    console.log('Error: Socks5 proxy rejected connection - Failure - RESOLVED - attempt:', attempt, 'total delay time:', connectionRetryDelays.slice(0, attempt).reduce((a, b) => a + b, 0));
+  }
+
+  return response!;
 }
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
-
   let metrics: Metrics | undefined;
   try {
-    const socksProxyAgent = new SocksProxyAgent('socks://localhost:1055');
-
     let isHttps = undefined; // Auto-detect, will be set for port 443
     if (!event.headers['ts-target-ip']) {
       return {
@@ -102,15 +132,13 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
     const response = await proxyHttpRequest({
       hostname: event.headers['ts-target-ip'],
       port: event.headers['ts-target-port'],
-      agent: socksProxyAgent,
     }, isHttps,
     {
       path: event.requestContext.http.path,
       headers: targetHeaders,
       method: event.requestContext.http.method,
       body: event.body,
-    },
-    );
+    });
 
     metrics?.addMetric('success', MetricUnit.Count, 1);
     return response;


### PR DESCRIPTION
Fixes https://github.com/rehanvdm/tailscale-lambda-extension/pull/4

This error: `Error: Socks5 proxy rejected connection - Failure` can happen during a cold start or a normal function call of the lambda. I believe that even though the tailscale process is running, the socks5 proxy has not fully initialized. This is more likely to happen on cold starts, it might also have to do with several logins to the tailscale networks at once.

In my tests only 1 retry attempt was needed, the 10ms delay was enough. We might be able to go lower, but I have not tested it. If we could go as low as 1ms or 0ms, it might mean the first request wakes something up/resets something, just a hunch. For now, I'm happy with a 10ms retry whenever this intermittent error happens.   