### PR TITLE
feat: fix auth header

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [Error Handling](#error-handling)
     - [Code Examples](#code-examples)
   - [Additional Information](#additional-information)
+  - [AWS SigV4 Headers](#aws-sigv4-headers)
 
 A CDK construct that creates an AWS Lambda Function acting as a transparent proxy to your Tailscale network.
 
@@ -127,8 +128,28 @@ When calling the Proxy, include the following headers to specify the target mach
 - `ts-target-port`: The port of the Tailscale-connected machine/device.
 - `ts-https`: OPTIONAL, if undefined, the default behaviour is to use https when the port is 443. If specified then it 
   will override the default behaviour.
+- See the remaining AWS SigV4 headers in the next section (special case for `Authorization`).
 
 These `ts-` headers are removed before the request is forwarded to the target machine.
+
+#### AWS SigV4 Headers
+
+The proxy automatically removes AWS SigV4 headers from the incoming request and replaces them with their `ts-` 
+prefixed counterparts when forwarding the request if they exist. This allows you to forward headers that
+are named the same as required by the AWS SigV4 signature request. 
+
+The following headers are handled:
+- `ts-authorization` → `Authorization`
+- `ts-x-amz-date` → `x-amz-date`
+- `ts-host` → `host`
+- `ts-x-amz-content-sha256` → `x-amz-content-sha256`
+
+This is useful when you need to include an `Authorization` header in the request to the target machine. If 
+you place the value directly in the `Authorization` header, it will be overwritten by the AWS SigV4 signature 
+that the caller generates. Instead, place your authorization value in the `ts-authorization` header. The 
+proxy will remove all `ts-` prefixed headers before forwarding the request and will correctly set the 
+`ts-authorization` value as the `Authorization` header in the forwarded request.
+
 
 ### Creating CloudWatch Tracking Metrics
 

--- a/src/lambda/tailscale-proxy/index.ts
+++ b/src/lambda/tailscale-proxy/index.ts
@@ -1,94 +1,15 @@
-import * as http from 'http';
-import * as https from 'https';
 import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
 import {
   APIGatewayProxyEventV2, APIGatewayProxyResultV2,
 } from 'aws-lambda';
-import { SocksProxyAgent } from 'socks-proxy-agent';
+import { proxyHttpRequest } from './proxy-http-request';
 
-async function proxyHttpRequest(
-  target: Pick<http.RequestOptions, 'hostname' | 'port'>,
-  isHttps: boolean | undefined,
-  request: {
-    path: string;
-    method: string;
-    headers: Record<string, string>;
-    body: string | undefined;
-  },
-): Promise<APIGatewayProxyResultV2> {
-
-  async function requestPromise(): Promise<APIGatewayProxyResultV2> {
-    const socksProxyAgent = new SocksProxyAgent('socks://localhost:1055');
-    return new Promise((resolve, reject) => {
-      const chunks: Buffer[] = [];
-      const httpLib = isHttps == undefined ?
-        (target.port == 443 ? https : http) :
-        (isHttps ? https : http);
-      const apiRequest = httpLib.request({
-        ...target,
-        agent: socksProxyAgent,
-        path: request.path,
-        method: request.method,
-        headers: request.headers,
-      }, (res: http.IncomingMessage) => {
-        res.on('data', (chunk: Buffer) => {
-          chunks.push(chunk);
-        });
-        res.on('end', () => {
-          const responseBody = Buffer.concat(chunks);
-          resolve({
-            statusCode: res.statusCode || 500,
-            headers: res.headers as Record<string, string>,
-            body: responseBody.toString('base64'),
-            isBase64Encoded: true,
-          });
-        });
-        res.on('error', (error: Error): void => {
-          console.error('Error receiving response:', error);
-          reject(error);
-        });
-      });
-
-      apiRequest.on('error', (error: Error): void => {
-        console.error('Error sending request:', error);
-        reject(error);
-      });
-
-      if (request.body != null) {
-        apiRequest.write(request.body);
-      }
-      apiRequest.end();
-    });
-  }
-
-
-  const connectionRetryDelays = [10, 50, 100, 500, 1000, 2000, 3000];
-  let attempt = 0;
-  let success = false;
-  let response: APIGatewayProxyResultV2;
-
-  do {
-    try {
-      response = await requestPromise();
-      success = true;
-    } catch (error) {
-      if (error == 'Error: Socks5 proxy rejected connection - Failure' && attempt < connectionRetryDelays.length) {
-        console.error('Error: Socks5 proxy rejected connection - Failure');
-        console.log('Retrying in', connectionRetryDelays[attempt], 'ms');
-        await new Promise((resolve) => setTimeout(resolve, connectionRetryDelays[attempt]));
-        attempt++;
-      } else {
-        throw error;
-      }
-    }
-  } while (!success && attempt < connectionRetryDelays.length);
-
-  if (attempt > 0) {
-    console.log('Error: Socks5 proxy rejected connection - Failure - RESOLVED - attempt:', attempt, 'total delay time:', connectionRetryDelays.slice(0, attempt).reduce((a, b) => a + b, 0));
-  }
-
-  return response!;
-}
+const AWS_SPECIFIC_HEADERS = [
+  'authorization',
+  'x-amz-date',
+  'host',
+  'x-amz-content-sha256',
+];
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
   let metrics: Metrics | undefined;
@@ -122,12 +43,27 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
       }
     }
 
-    const targetHeaders = { ...event.headers } as Record<string, string>;
-    delete targetHeaders['ts-target-ip'];
-    delete targetHeaders['ts-target-port'];
-    if (targetHeaders['ts-metric-service']) {delete targetHeaders['ts-metric-service'];}
-    if (targetHeaders['ts-metric-dimension-name']) {delete targetHeaders['ts-metric-dimension-name'];}
-    if (targetHeaders['ts-metric-dimension-value']) {delete targetHeaders['ts-metric-dimension-value'];}
+    // Create target headers by filtering out AWS-specific and ts-* headers
+    const targetHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(event.headers)) {
+      if (!key.startsWith('ts-') && !AWS_SPECIFIC_HEADERS.includes(key.toLowerCase())) {
+        targetHeaders[key] = value as string;
+      }
+    }
+
+    // Handle AWS SigV4 header replacements if they exist
+    if (event.headers['ts-authorization']) {
+      targetHeaders.Authorization = event.headers['ts-authorization'] as string;
+    }
+    if (event.headers['ts-x-amz-date']) {
+      targetHeaders['x-amz-date'] = event.headers['ts-x-amz-date'] as string;
+    }
+    if (event.headers['ts-host']) {
+      targetHeaders.host = event.headers['ts-host'] as string;
+    }
+    if (event.headers['ts-x-amz-content-sha256']) {
+      targetHeaders['x-amz-content-sha256'] = event.headers['ts-x-amz-content-sha256'] as string;
+    }
 
     const response = await proxyHttpRequest({
       hostname: event.headers['ts-target-ip'],

--- a/src/lambda/tailscale-proxy/proxy-http-request.ts
+++ b/src/lambda/tailscale-proxy/proxy-http-request.ts
@@ -1,0 +1,86 @@
+import * as http from 'http';
+import * as https from 'https';
+import { APIGatewayProxyResultV2 } from 'aws-lambda';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+
+export async function proxyHttpRequest(
+  target: Pick<http.RequestOptions, 'hostname' | 'port'>,
+  isHttps: boolean | undefined,
+  request: {
+    path: string;
+    method: string;
+    headers: Record<string, string>;
+    body: string | undefined;
+  },
+): Promise<APIGatewayProxyResultV2> {
+  async function requestPromise(): Promise<APIGatewayProxyResultV2> {
+    const socksProxyAgent = new SocksProxyAgent('socks://localhost:1055');
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      const httpLib = isHttps == undefined ?
+        (target.port == 443 ? https : http) :
+        (isHttps ? https : http);
+      const apiRequest = httpLib.request({
+        ...target,
+        agent: socksProxyAgent,
+        path: request.path,
+        method: request.method,
+        headers: request.headers,
+      }, (res: http.IncomingMessage) => {
+        res.on('data', (chunk: Buffer) => {
+          chunks.push(chunk);
+        });
+        res.on('end', () => {
+          const responseBody = Buffer.concat(chunks);
+          resolve({
+            statusCode: res.statusCode || 500,
+            headers: res.headers as Record<string, string>,
+            body: responseBody.toString('base64'),
+            isBase64Encoded: true,
+          });
+        });
+        res.on('error', (error: Error): void => {
+          console.error('Error receiving response:', error);
+          reject(error);
+        });
+      });
+
+      apiRequest.on('error', (error: Error): void => {
+        console.error('Error sending request:', error);
+        reject(error);
+      });
+
+      if (request.body != null) {
+        apiRequest.write(request.body);
+      }
+      apiRequest.end();
+    });
+  }
+
+  const connectionRetryDelays = [10, 50, 100, 500, 1000, 2000, 3000];
+  let attempt = 0;
+  let success = false;
+  let response: APIGatewayProxyResultV2;
+
+  do {
+    try {
+      response = await requestPromise();
+      success = true;
+    } catch (error) {
+      if (error == 'Error: Socks5 proxy rejected connection - Failure' && attempt < connectionRetryDelays.length) {
+        console.error('Error: Socks5 proxy rejected connection - Failure');
+        console.log('Retrying in', connectionRetryDelays[attempt], 'ms');
+        await new Promise((resolve) => setTimeout(resolve, connectionRetryDelays[attempt]));
+        attempt++;
+      } else {
+        throw error;
+      }
+    }
+  } while (!success && attempt < connectionRetryDelays.length);
+
+  if (attempt > 0) {
+    console.log('Error: Socks5 proxy rejected connection - Failure - RESOLVED - attempt:', attempt, 'total delay time:', connectionRetryDelays.slice(0, attempt).reduce((a, b) => a + b, 0));
+  }
+
+  return response!;
+}

--- a/test/tailscale-proxy.test.ts
+++ b/test/tailscale-proxy.test.ts
@@ -1,0 +1,133 @@
+import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { handler } from '../src/lambda/tailscale-proxy';
+import * as proxyHttpRequest from '../src/lambda/tailscale-proxy/proxy-http-request';
+
+function createMockSigv4InvocationEvent(ip: string, port: string, method: string, path: string, body?: string,
+  headers?: Record<string, string>): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'ANY /{proxy+}',
+    rawPath: path,
+    rawQueryString: '',
+    headers: {
+      'ts-target-ip': ip,
+      'ts-target-port': port,
+      ...headers,
+
+      // Headers needed to call the Lamba with Sigv4
+      'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=test',
+      'x-amz-date': 'xxx',
+      'host': 'xxx',
+      'x-amz-content-sha256': 'xxx',
+    },
+    body: body,
+    requestContext: {
+      http: {
+        method: method,
+        path: path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'test-agent',
+      },
+      routeKey: 'ANY /{proxy+}',
+      stage: '$default',
+      requestId: 'test-request-id',
+      accountId: 'test-account-id',
+      apiId: 'test-api-id',
+      domainName: 'test-domain',
+      domainPrefix: 'test',
+      time: '2024-01-01T00:00:00Z',
+      timeEpoch: 1704067200000,
+    },
+    isBase64Encoded: false,
+  };
+}
+
+describe('Authorization header handling', () => {
+
+  it('no additional auth header to target', async () => {
+    const event = createMockSigv4InvocationEvent(
+      '192.168.0.1',
+      '80',
+      'GET',
+      '/test/path',
+      undefined,
+      {
+        extra: 'extra',
+      },
+    );
+
+    const proxyHttpRequestResponse: APIGatewayProxyResultV2 = {
+      statusCode: 200,
+      headers: {},
+      body: '',
+      isBase64Encoded: false,
+    };
+    const proxyHttpRequestMock = jest.spyOn(proxyHttpRequest, 'proxyHttpRequest')
+      .mockResolvedValue(proxyHttpRequestResponse);
+
+    const response = await handler(event);
+    // Proxy returns the exact same data as we get from the target
+    expect(response).toEqual(proxyHttpRequestResponse);
+    // Ensure we call with the target expected arguments
+    expect(proxyHttpRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: '192.168.0.1',
+        port: '80',
+      }),
+      undefined,
+      expect.objectContaining({
+        headers: {
+          extra: 'extra',
+        },
+      }),
+    );
+
+    // Restore the original implementation
+    jest.restoreAllMocks();
+  });
+
+  it('include auth header to target', async () => {
+    const event = createMockSigv4InvocationEvent(
+      '192.168.0.1',
+      '80',
+      'GET',
+      '/test/path',
+      undefined,
+      {
+        'ts-authorization': 'PASS THIS',
+        'extra': 'extra',
+      },
+    );
+
+    const proxyHttpRequestResponse: APIGatewayProxyResultV2 = {
+      statusCode: 200,
+      headers: {},
+      body: '',
+      isBase64Encoded: false,
+    };
+    const proxyHttpRequestMock = jest.spyOn(proxyHttpRequest, 'proxyHttpRequest')
+      .mockResolvedValue(proxyHttpRequestResponse);
+
+    const response = await handler(event);
+    // Proxy returns the exact same data as we get from the target
+    expect(response).toEqual(proxyHttpRequestResponse);
+    // Ensure we call with the target expected arguments
+    expect(proxyHttpRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: '192.168.0.1',
+        port: '80',
+      }),
+      undefined,
+      expect.objectContaining({
+        headers: {
+          Authorization: 'PASS THIS',
+          extra: 'extra',
+        },
+      }),
+    );
+
+    // Restore the original implementation
+    jest.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
Fixes a bug that when calling the Proxy authenticated. The AWS Signature v4 request headers includes Authorization, this overrides the Authorization header that you specify and send to the target. This fix allow you to place the Authorization header in the `ts-authorization` header to not have it overriden and passed to the target correctly. 

Closes #3 